### PR TITLE
Change source of dependency on 'System.Data.SqlClient'

### DIFF
--- a/DbConn.DbExecutor.Dapper/DbConn.DbExecutor.Dapper.csproj
+++ b/DbConn.DbExecutor.Dapper/DbConn.DbExecutor.Dapper.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.4" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The source of dependency on 'System.Data.SqlClient' was changed from SDK to Nuget